### PR TITLE
fix hubble logout

### DIFF
--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -28,8 +28,11 @@ class Auth:
             redirect_url = 'http://localhost:8085'
 
             async with session.get(
-                url=f'{api_host}user.identity.authorize?'
-                f'provider=jina-login&redirectUri={redirect_url}'
+                url=urljoin(
+                    api_host,
+                    'user.identity.authorize?provider=jina-login&redirectUri=',
+                )
+                + redirect_url
             ) as response:
                 response.raise_for_status()
                 json_response = await response.json()
@@ -67,7 +70,7 @@ class Auth:
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                url=f'{api_host}user.identity.grant.auth0Unified',
+                url=urljoin(api_host, 'user.identity.grant.auth0Unified'),
                 data=post_data,
             ) as response:
                 response.raise_for_status()

--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -2,6 +2,7 @@ import os
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs
+from requests.compat import urljoin
 
 import aiohttp
 from hubble.utils.api_utils import get_base_url
@@ -84,7 +85,7 @@ class Auth:
             session.headers.update({'Authorization': f'token {Auth.get_auth_token()}'})
 
             async with session.post(
-                url=f'{api_host}/user.session.dismiss',
+                url=urljoin(api_host, 'user.session.dismiss')
             ) as response:
                 json_response = await response.json()
                 if json_response['code'] == 401:

--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -2,11 +2,11 @@ import os
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs
-from requests.compat import urljoin
 
 import aiohttp
 from hubble.utils.api_utils import get_base_url
 from hubble.utils.config import config
+from requests.compat import urljoin
 
 
 class Auth:


### PR DESCRIPTION
The logout function did not work, because there was a double slash in the url. To make sure that a valid url is constructed, I used the `urljoin`function. 