### PR TITLE
feat: allow get token from env

### DIFF
--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -1,3 +1,4 @@
+import os
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs
@@ -10,7 +11,13 @@ from hubble.utils.config import config
 class Auth:
     @staticmethod
     def get_auth_token():
-        return config.get('auth_token')
+        """Get user auth token.
+
+        .. note:: We first check `JINA_AUTH_TOKEN` environment variable.
+          if token is not None, use env token. Otherwise, we get token from config.
+        """
+        token_from_env = os.environ.get('JINA_AUTH_TOKEN')
+        return token_from_env if token_from_env else config.get('auth_token')
 
     @staticmethod
     async def login():

--- a/tests/unit/utils/config.json
+++ b/tests/unit/utils/config.json
@@ -1,0 +1,1 @@
+{"auth_token": "my-token"}

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+from hubble.utils import auth
 from hubble.utils.config import CONFIG_FILE_NAME, ROOT_ENV_NAME, Config
 
 
@@ -27,3 +28,14 @@ def test_config(config, config_path):
     assert config_path.exists()
     config.purge()
     assert not config_path.exists()
+
+
+def test_get_auth_token(config, config_path):
+    auth.config = config
+    config.set('auth_token', 'my-token')
+    assert config.get('auth_token') == 'my-token'
+    assert auth.Auth.get_auth_token() == 'my-token'
+
+    os.environ['JINA_AUTH_TOKEN'] = 'my-token-from-env'
+    assert config.get('auth_token') == 'my-token'
+    assert auth.Auth.get_auth_token() == 'my-token-from-env'


### PR DESCRIPTION
Discussed with @delgermurun , in the hubble python client, we first try to get token from env, then get token from configuration. This is needed inside Finetuner.runner, since we can not login, but we pass token as environment variable. We need a patch release after this PR.

link to https://github.com/jina-ai/finetuner.fit/issues/188 and https://github.com/jina-ai/finetuner-api/pull/56