### PR TITLE
feat: support upload bytesio

### DIFF
--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -64,14 +64,14 @@ class Client(BaseClient):
 
     def upload_artifact(
         self,
-        path: Union[str, io.BytesIO],
+        f: Union[str, io.BytesIO],
         id: Optional[str] = None,
         metadata: Optional[dict] = None,
         is_public: bool = False,
     ) -> Union[requests.Response, dict]:
         """Upload artifact to Hubble Artifact Storage.
 
-        :param path: The full path or the `io.BytesIO` of the file to be uploaded.
+        :param f: The full path or the `io.BytesIO` of the file to be uploaded.
         :param id: Optional value, the id of the artifact.
         :param metadata: Optional value, the metadata of the artifact.
         :param is_public: Optional value, if this artifact is public or not,
@@ -79,13 +79,13 @@ class Client(BaseClient):
         :returns: `requests.Response` object as returned value
             or indented json if jsonify.
         """
-        if isinstance(path, str):
-            files = {'file': open(path, 'rb')}
-        elif isinstance(path, io.BytesIO):
-            files = {'file': path}
+        if isinstance(f, str):
+            files = {'file': open(f, 'rb')}
+        elif isinstance(f, io.BytesIO):
+            files = {'file': f}
         else:
             raise TypeError(
-                f'Unexpected type {type(path)}, expect either `str` or `io.BytesIO`.'
+                f'Unexpected type {type(f)}, expect either `str` or `io.BytesIO`.'
             )
 
         return self.handle_request(

--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -85,7 +85,7 @@ class Client(BaseClient):
             files = {'file': path}
         else:
             raise TypeError(
-                f'Unexpected file type {type(path)}, expect either `str` or `io.BytesIO`.'
+                f'Unexpected type {type(path)}, expect either `str` or `io.BytesIO`.'
             )
 
         return self.handle_request(

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -37,12 +37,10 @@ def test_get_user_info(client):
 def test_upload_get_delete_artifact(client, tmpdir):
     # upload from path.
     artifact_dir = os.path.join(cur_dir, '../resources/model')
-    resp = client.upload_artifact(path=artifact_dir)
+    resp = client.upload_artifact(f=artifact_dir)
     assert resp.ok
     # upload from bytesio
-    resp = client.upload_artifact(
-        path=io.BytesIO(b"some initial binary data: \x00\x01")
-    )
+    resp = client.upload_artifact(f=io.BytesIO(b"some initial binary data: \x00\x01"))
     assert resp.ok
     artifact_id = resp.json()['data']['_id']
     resp = client.get_artifact_info(id=artifact_id)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,3 +1,4 @@
+import io
 import os
 import uuid
 
@@ -34,8 +35,14 @@ def test_get_user_info(client):
 
 
 def test_upload_get_delete_artifact(client, tmpdir):
+    # upload from path.
     artifact_dir = os.path.join(cur_dir, '../resources/model')
     resp = client.upload_artifact(path=artifact_dir)
+    assert resp.ok
+    # upload from bytesio
+    resp = client.upload_artifact(
+        path=io.BytesIO(b"some initial binary data: \x00\x01")
+    )
     assert resp.ok
     artifact_id = resp.json()['data']['_id']
     resp = client.get_artifact_info(id=artifact_id)


### PR DESCRIPTION
Support upload an byteIO object. 

Why? In Finetuner, we want to reserve an `artifact_id` by uploading a placeholder object without creating a real object.
The impact: when calling `upload_artifact` with `path`, please replace `path` to `f`.