### PR TITLE
pref(artifact): check login before upload

### DIFF
--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -83,6 +83,8 @@ class Client(BaseClient):
 
         from ..utils.pbar import get_progressbar
 
+        self.get_user_info()  # to make sure the user is logged in.
+
         pbar = get_progressbar(disable=not show_progress)
 
         class BufferReader(io.BytesIO):


### PR DESCRIPTION
An authentication error is raised after the whole file is sent if the user is not logged in, which takes a lot of time.

So trying to fetch user info before the upload request, which will produce the same error if the user is not logged in.

Fixes #24 