### PR TITLE
feat: change the way throw error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
         run: make test
         env:
           JINA_AUTH_TOKEN: ${{secrets.JINA_AUTH_TOKEN}}
-          JINA_HUBBLE_REGISTRY: https://apihubble.staging.jina.ai
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: make test
         env:
-          HUBBLE_ACCESS_TOKEN: ${{secrets.HUBBLE_ACCESS_TOKEN}}
+          JINA_AUTH_TOKEN: ${{secrets.HUBBLE_ACCESS_TOKEN}}
           JINA_HUBBLE_REGISTRY: https://apihubble.staging.jina.ai
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: make test
         env:
-          JINA_AUTH_TOKEN: ${{secrets.HUBBLE_ACCESS_TOKEN}}
+          JINA_AUTH_TOKEN: ${{secrets.JINA_AUTH_TOKEN}}
           JINA_HUBBLE_REGISTRY: https://apihubble.staging.jina.ai
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/style-and-test-check.yml
+++ b/.github/workflows/style-and-test-check.yml
@@ -20,7 +20,6 @@ jobs:
         run: make test
         env:
           JINA_AUTH_TOKEN: ${{secrets.JINA_AUTH_TOKEN}}
-          JINA_HUBBLE_REGISTRY: https://apihubble.staging.jina.ai
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/style-and-test-check.yml
+++ b/.github/workflows/style-and-test-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run tests
         run: make test
         env:
-          JINA_AUTH_TOKEN: ${{secrets.HUBBLE_ACCESS_TOKEN}}
+          JINA_AUTH_TOKEN: ${{secrets.JINA_AUTH_TOKEN}}
           JINA_HUBBLE_REGISTRY: https://apihubble.staging.jina.ai
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/style-and-test-check.yml
+++ b/.github/workflows/style-and-test-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run tests
         run: make test
         env:
-          HUBBLE_ACCESS_TOKEN: ${{secrets.HUBBLE_ACCESS_TOKEN}}
+          JINA_AUTH_TOKEN: ${{secrets.HUBBLE_ACCESS_TOKEN}}
           JINA_HUBBLE_REGISTRY: https://apihubble.staging.jina.ai
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -117,11 +117,10 @@ client = hubble.Client()
 
 try:
     client.get_user_info()
-except Exception as ex:
-    if (isinstance(ex, hubble.excepts.AuthenticationRequiredError)):
-        print('Please login first.')
-    else:
-        print('Unknown error')
+except hubble.excepts.AuthenticationRequiredError:
+    print('Please login first.')
+except Exception:
+    print('Unknown error')
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -109,10 +109,35 @@ response = client.list_artifacts(filter={'metaData.foo': 'bar'}, sort={'type': -
 response = client.delete_artifact(id='my-artifact-id')
 ```
 
-## Release cycle
+### Error Handling
+```python
+import hubble
+
+client = hubble.Client()
+
+try:
+    client.get_user_info()
+except Exception as ex:
+    if (isinstance(ex, hubble.excepts.AuthenticationRequiredError)):
+        print('Please login first.')
+    else:
+        print('Unknown error')
+```
+
+## Development
+
+### Local test
+
+- Make a new virtual env. `make env`
+- Install dependencies. `make init`
+- Login Jina account. `jina auth login`
+- Test locally. `make test`
+
+### Release cycle
 
 - Each time new commits come into `main` branch, CD workflow will generate a new release both on GitHub and Pypi.
 - Each time new commits come into `alpha` branch, CD workflow will generate a new pre-release both on GitHub and Pypi.
+
 
 <!-- start support-pitch -->
 ## Support

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ except Exception as ex:
 
 - Make a new virtual env. `make env`
 - Install dependencies. `make init`
-- Login Jina account. `jina auth login`
+- **The test should be run in a logged in environment**. So need to login to Jina. `jina auth login`
 - Test locally. `make test`
 
 ### Release cycle

--- a/hubble/client/base.py
+++ b/hubble/client/base.py
@@ -21,13 +21,12 @@ class BaseClient(object):
         max_retries: Optional[int] = None,
         jsonify: bool = False,
     ):
-        self._token = token if token else Auth.get_auth_token()
-        if not self._token:
-            raise ValueError(
-                'We can not get the token, please call `hubble.login()` first.'
-            )
         self._session = HubbleAPISession()
-        self._session.init_jwt_auth(token=self._token)
+
+        self._token = token if token else Auth.get_auth_token()
+        if self._token:
+            self._session.init_jwt_auth(token=self._token)
+
         self._base_url = get_base_url()
         self._jsonify = jsonify
         if max_retries:

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -9,13 +9,7 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture
-def client(mocker, request):
-    # note this token is set in secrets.
-    # to run it locally please replace it with your token.
-    mocker.patch(
-        'hubble.utils.auth.Auth.get_auth_token',
-        return_value=os.environ.get('HUBBLE_ACCESS_TOKEN'),
-    )
+def client(request):
     return Client(**getattr(request, 'param', {}))
 
 

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -6,7 +6,7 @@ from hubble import Client
 from hubble.excepts import AuthenticationRequiredError
 
 
-@patch.dict(os.environ, {"JINA_AUTH_TOKEN": ""})
+@patch.dict(os.environ, {'JINA_AUTH_TOKEN': ''})
 @pytest.mark.parametrize('params', [{'jsonify': True}, {'jsonify': False}])
 def test_handle_error_request(mocker, params):
     client = Client(**params)

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -3,16 +3,10 @@ from hubble import Client
 from hubble.excepts import AuthenticationRequiredError
 
 
-def test_handle_error_request(mocker):
-    mocker.patch('hubble.utils.auth.Auth.get_auth_token', return_value='fake-token')
+@pytest.mark.parametrize('params', [{'jsonify': True}, {'jsonify': False}])
+def test_handle_error_request(mocker, params):
+    client = Client(**params)
+
+    mocker.patch('hubble.utils.auth.Auth.get_auth_token', return_value=None)
     with pytest.raises(AuthenticationRequiredError):
-        client = Client()
         client.get_user_info()
-
-
-def test_client_jsonify(mocker):
-    mocker.patch('hubble.utils.auth.Auth.get_auth_token', return_value='fake-token')
-    with pytest.raises(AuthenticationRequiredError):
-        client = Client(jsonify=True)
-        resp = client.get_user_info()
-        assert isinstance(resp, str)

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -1,8 +1,12 @@
+import os
+from unittest.mock import patch
+
 import pytest
 from hubble import Client
 from hubble.excepts import AuthenticationRequiredError
 
 
+@patch.dict(os.environ, {"JINA_AUTH_TOKEN": ""})
 @pytest.mark.parametrize('params', [{'jsonify': True}, {'jsonify': False}])
 def test_handle_error_request(mocker, params):
     client = Client(**params)

--- a/tests/unit/utils/test_api_utils.py
+++ b/tests/unit/utils/test_api_utils.py
@@ -1,9 +1,0 @@
-import os
-
-from hubble.utils.api_utils import get_base_url
-
-
-def test_get_base_url():
-    base_url = get_base_url()
-    domain = os.environ['JINA_HUBBLE_REGISTRY']
-    assert base_url == f'{domain}/v2/rpc/'

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from hubble.utils import auth
@@ -30,7 +31,8 @@ def test_config(config, config_path):
     assert not config_path.exists()
 
 
-def test_get_auth_token(config, config_path):
+@patch.dict(os.environ, {"JINA_AUTH_TOKEN": ""})
+def test_get_auth_token(config):
     auth.config = config
     config.set('auth_token', 'my-token')
     assert config.get('auth_token') == 'my-token'

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -31,7 +31,7 @@ def test_config(config, config_path):
     assert not config_path.exists()
 
 
-@patch.dict(os.environ, {"JINA_AUTH_TOKEN": ""})
+@patch.dict(os.environ, {'JINA_AUTH_TOKEN': ''})
 def test_get_auth_token(config):
     auth.config = config
     config.set('auth_token', 'my-token')


### PR DESCRIPTION
Don't throw error during new Client, if there
is no authentication info. Instead, throw error when
actually calling according API.

Related to: https://github.com/jina-ai/auth/issues/2


---

@bwanglzu This is a breaking change, please change the usage accordingly in finetuner. 