### PR TITLE
feat: allow download as bytesio obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ response = client.get_artifact_info(id='my-artifact-id')
 # Download artifact to local directory.
 response = client.download_artifact(
     id='my-artifact-id',
-    path='my-local-filepath'
+    f='my-local-filepath'
 )
 
 # Get list of artifacts.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ response = client.download_artifact(
     id='my-artifact-id',
     f='my-local-filepath'
 )
+# Download artifact as an io.BytesIO object
+response = client.download_artifact(
+    id='my-artifact-id',
+    f=io.BytesIO()
+)
 
 # Get list of artifacts.
 response = client.list_artifacts(filter={'metaData.foo': 'bar'}, sort={'type': -1})

--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -138,13 +138,13 @@ class Client(BaseClient):
             )
 
     def download_artifact(
-        self, id: str, path: Union[str, io.BytesIO], show_progress: bool = False
+        self, id: str, f: Union[str, io.BytesIO], show_progress: bool = False
     ) -> str:
         """Download artifact from Hubble Artifact Storage to localhost.
 
         :param id: The id of the artifact to be downloaded.
-        :param path: The full path or the `io.BytesIO` of the file to be downloaded.
-        :returns: A str object indicates the download path on localhost.
+        :param f: The full path or the `io.BytesIO` of the file to be downloaded.
+        :returns: A str object indicates the download path on localhost or bytes.
         """
         from rich import filesize
 
@@ -173,19 +173,19 @@ class Client(BaseClient):
                     total_size=str(filesize.decimal(total)),
                 )
 
-                if isinstance(path, str):
-                    with open(path, 'wb') as f:
+                if isinstance(f, str):
+                    with open(f, 'wb') as writer:
                         for data in response.iter_content(chunk_size=1024 * 1024):
-                            f.write(data)
+                            writer.write(data)
                             pbar.update(task, advance=len(data))
-                        return path
-                elif isinstance(path, io.BytesIO):
+                        return f
+                elif isinstance(f, io.BytesIO):
                     for data in response.iter_content(chunk_size=1024 * 1024):
                         yield data
                         pbar.update(task, advance=len(data))
                 else:
                     raise TypeError(
-                        f'Unexpected type {type(path)}, expect either `str` or `io.BytesIO`.'
+                        f'Unexpected type {type(f)}, expect either `str` or `io.BytesIO`.'
                     )
 
     def delete_artifact(self, id: str) -> Union[requests.Response, dict]:

--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -178,16 +178,16 @@ class Client(BaseClient):
                         for data in response.iter_content(chunk_size=1024 * 1024):
                             writer.write(data)
                             pbar.update(task, advance=len(data))
-                        return f
                 elif isinstance(f, io.BytesIO):
                     for data in response.iter_content(chunk_size=1024 * 1024):
-                        yield data
+                        f.write(data)
                         pbar.update(task, advance=len(data))
                 else:
                     raise TypeError(
                         f'Unexpected type {type(f)}, expect either'
                         '`str` or `io.BytesIO`.'
                     )
+        return f
 
     def delete_artifact(self, id: str) -> Union[requests.Response, dict]:
         """Delete the artifact from Hubble Artifact Storage.

--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -185,7 +185,8 @@ class Client(BaseClient):
                         pbar.update(task, advance=len(data))
                 else:
                     raise TypeError(
-                        f'Unexpected type {type(f)}, expect either `str` or `io.BytesIO`.'
+                        f'Unexpected type {type(f)}, expect either'
+                        '`str` or `io.BytesIO`.'
                     )
 
     def delete_artifact(self, id: str) -> Union[requests.Response, dict]:

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -87,3 +87,22 @@ def test_upload_get_delete_artifact(client, tmpdir):
         resp = client.delete_artifact(id=artifact_id)
 
         assert_response(resp)
+
+
+def test_upload_download_artifact_as_bytesio(client):
+    # upload from path.
+    data = b'some initial binary data: \x00\x01'
+    resp = client.upload_artifact(f=io.BytesIO(data), show_progress=True)
+    assert_response(resp)
+
+    if not client._jsonify:
+        resp = resp.json()
+
+    artifact_id1 = resp['data']['_id']
+
+    # download as buffer
+    obj = io.BytesIO()
+    resp = client.download_artifact(artifact_id1, path=obj)
+    for chunk in resp:
+        assert isinstance(chunk, bytes)
+        assert chunk == data

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -75,7 +75,7 @@ def test_upload_get_delete_artifact(client, tmpdir):
     assert_response(resp)
 
     downloaded_artifact = client.download_artifact(
-        id=artifact_id2, path=os.path.join(tmpdir, 'model'), show_progress=True
+        id=artifact_id2, f=os.path.join(tmpdir, 'model'), show_progress=True
     )
     assert os.path.isfile(downloaded_artifact)
 
@@ -103,6 +103,6 @@ def test_upload_download_artifact_bytes(client):
     # download as buffer
     obj = io.BytesIO()
     resp = client.download_artifact(artifact_id1, f=obj)
-    for chunk in resp:
-        assert isinstance(chunk, bytes)
-        assert chunk == data
+    assert isinstance(resp, io.BytesIO)
+    resp.seek(0)
+    assert resp.read() == data

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -89,7 +89,7 @@ def test_upload_get_delete_artifact(client, tmpdir):
         assert_response(resp)
 
 
-def test_upload_download_artifact_as_bytesio(client):
+def test_upload_download_artifact_bytes(client):
     # upload from path.
     data = b'some initial binary data: \x00\x01'
     resp = client.upload_artifact(f=io.BytesIO(data), show_progress=True)
@@ -102,7 +102,7 @@ def test_upload_download_artifact_as_bytesio(client):
 
     # download as buffer
     obj = io.BytesIO()
-    resp = client.download_artifact(artifact_id1, path=obj)
+    resp = client.download_artifact(artifact_id1, f=obj)
     for chunk in resp:
         assert isinstance(chunk, bytes)
         assert chunk == data


### PR DESCRIPTION
allow download as bytes io object.

Note: this is a breaking change to `download_artifact`.