### PR TITLE
feat: send docarray v info to backend

### DIFF
--- a/hubble/executor/__init__.py
+++ b/hubble/executor/__init__.py
@@ -15,3 +15,5 @@ class HubExecutor:
     archive_url: Optional[str] = None
     md5sum: Optional[str] = None
     build_env: Optional[list] = None
+    jina_version: Optional[str] = None
+    docarray_version: Optional[str] = None

--- a/hubble/executor/hubio.py
+++ b/hubble/executor/hubio.py
@@ -1058,8 +1058,16 @@ metas:
             return resp
 
         pull_url = urljoin(hubble.utils.get_base_url(), 'executor.getPackage')
+        try:
+            from jina import __version__ as jina_version
+        except ImportError:
+            jina_version = __unset_msg__
+        try:
+            from docarray import __version__ as docarray_version
+        except ImportError:
+            docarray_version = __unset_msg__
 
-        payload = {'id': name, 'include': ['code'], 'rebuildImage': rebuild_image}
+        payload = {'id': name, 'include': ['code'], 'rebuildImage': rebuild_image, 'jina': jina_version, 'docarray': docarray_version}
         if image_required:
             payload['include'].append('docker')
         if secret:
@@ -1091,6 +1099,8 @@ metas:
             archive_url=resp['package']['download'],
             md5sum=resp['package']['md5'],
             build_env=list(buildEnv.keys()) if buildEnv else [],
+            jina_version=jina_version,
+            docarray_version=docarray_version
         )
 
     @staticmethod
@@ -1106,6 +1116,10 @@ metas:
             from jina import __version__ as jina_version
         except ImportError:
             jina_version = __unset_msg__
+        try:
+            from docarray import __version__ as docarray_version
+        except ImportError:
+            docarray_version = __unset_msg__
 
         args_copy = copy.deepcopy(args)
         if not isinstance(args_copy, Dict):
@@ -1116,6 +1130,7 @@ metas:
             'name': name,
             'tag': tag if tag else 'latest',
             'jina': jina_version,
+            'docarray': docarray_version,
             'args': args_copy,
             'secret': secret,
         }


### PR DESCRIPTION
This is quite a naive way to start a discussion about how does `docarray` version is sent to the backend?