### PR TITLE
Migrate from python-jose to PyJWT

### DIFF
--- a/hubble/utils/jwks.py
+++ b/hubble/utils/jwks.py
@@ -1,4 +1,5 @@
 import requests
+from jwt import PyJWK
 
 from .api_utils import get_domain_url, get_json_from_response
 from .config import config
@@ -12,7 +13,7 @@ class JSONWebKeySet:
         if len(matching_jwks) > 0:
             return matching_jwks
         hubble_jwks = JSONWebKeySet.get_keys_from_hubble()
-        matching_jwks = [key for key in hubble_jwks if key['kid'] == kid]
+        matching_jwks = [PyJWK(key) for key in hubble_jwks if key['kid'] == kid]
         return matching_jwks
 
     @staticmethod

--- a/hubble/utils/jwt_parser.py
+++ b/hubble/utils/jwt_parser.py
@@ -1,7 +1,7 @@
 import base64
 import json
 
-from jose import jwt
+import jwt
 
 from .jwks import JSONWebKeySet
 
@@ -44,7 +44,7 @@ def validate_jwt(token: str, aud: str = None):
     try:
         decoded = jwt.decode(
             token,
-            json.dumps(keys[0]),
+            keys[0],
             algorithms=supported_algorithms,
             audience=aud,
             options={

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ filelock
 pathspec
 docker
 pyyaml
-python-jose
+pyjwt[crypto]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import tempfile
 
 import pytest
-from jose import jwt
+import jwt
 
 
 @pytest.fixture(autouse=True)
@@ -12,7 +12,7 @@ def tmpfile(tmpdir):
 
 @pytest.fixture()
 def generate_jwt(mocker):
-    private_key = {
+    private_key = jwt.PyJWK({
         "kty": "EC",
         "d": "iLw805NZwMRKwcXOmtDPGlB158S_PUkRVnlbmEMmO2E",
         "use": "sig",
@@ -21,9 +21,9 @@ def generate_jwt(mocker):
         "x": "KmpjXcs-ZoVBTqhzI5rlTqq0-BASZUOUINkYCcZG9K8",
         "y": "z-jGVJXhv1pfh_ic8wWTE30p_2JT0aTshfxx_TtiMm0",
         "alg": "ES256",
-    }
+    })
 
-    public_key = {
+    public_key = jwt.PyJWK({
         "kty": "EC",
         "use": "sig",
         "crv": "P-256",
@@ -31,9 +31,9 @@ def generate_jwt(mocker):
         "x": "KmpjXcs-ZoVBTqhzI5rlTqq0-BASZUOUINkYCcZG9K8",
         "y": "z-jGVJXhv1pfh_ic8wWTE30p_2JT0aTshfxx_TtiMm0",
         "alg": "ES256",
-    }
+    })
 
-    headers = {'kid': public_key['kid']}
+    headers = {'kid': public_key.key_id}
 
     mocker.patch('hubble.utils.jwks.JSONWebKeySet.get_keys', return_value=[public_key])
 

--- a/tests/unit/utils/test_jwt_parser.py
+++ b/tests/unit/utils/test_jwt_parser.py
@@ -6,9 +6,9 @@ from hubble.utils.jwt_parser import (
     validate_back_channel_logout_jwt,
     validate_jwt,
 )
-from jose import jwt
+import jwt
 
-PRIVATE_KEY = {
+PRIVATE_KEY = jwt.PyJWK({
     "kty": "EC",
     "d": "iLw805NZwMRKwcXOmtDPGlB158S_PUkRVnlbmEMmO2E",
     "use": "sig",
@@ -17,9 +17,9 @@ PRIVATE_KEY = {
     "x": "KmpjXcs-ZoVBTqhzI5rlTqq0-BASZUOUINkYCcZG9K8",
     "y": "z-jGVJXhv1pfh_ic8wWTE30p_2JT0aTshfxx_TtiMm0",
     "alg": "ES256",
-}
+})
 
-PUBLIC_KEY = {
+PUBLIC_KEY = jwt.PyJWK({
     "kty": "EC",
     "use": "sig",
     "crv": "P-256",
@@ -27,9 +27,9 @@ PUBLIC_KEY = {
     "x": "KmpjXcs-ZoVBTqhzI5rlTqq0-BASZUOUINkYCcZG9K8",
     "y": "z-jGVJXhv1pfh_ic8wWTE30p_2JT0aTshfxx_TtiMm0",
     "alg": "ES256",
-}
+})
 
-OTHER_PUBLIC_KEY = {
+OTHER_PUBLIC_KEY = jwt.PyJWK({
     "kty": "EC",
     "use": "sig",
     "crv": "P-256",
@@ -37,9 +37,9 @@ OTHER_PUBLIC_KEY = {
     "x": "_KCLiE8ul1eTVWdObu31mF26a3BzIsP2G6b2wPYlHFA",
     "y": "N6e_WdVrjjxVPZScBVLdluPk91pqoDRyS1BZ0ImDzPI",
     "alg": "ES256",
-}
+})
 
-HEADERS = {'kid': PUBLIC_KEY['kid']}
+HEADERS = {'kid': PUBLIC_KEY.key_id}
 
 PAYLOAD = {
     'iss': 'http://localhost:3000',


### PR DESCRIPTION
python-jose is no longer maintained and contains some vulnerabilities such as https://github.com/mpdavis/python-jose/issues/341.

Therefore, we replace python-jose with PyJWT with is almost API-compatible and still maintained.

--

I can't _really_ test this because the login functionality seems kinda broken (with and without this PR)?